### PR TITLE
Use a tuple instead of a list when passing args to a threaded function

### DIFF
--- a/gitstats/lib/task_manager.py
+++ b/gitstats/lib/task_manager.py
@@ -2,7 +2,6 @@
 
 import threading
 
-from time import sleep
 
 class TaskManager(object):
 


### PR DESCRIPTION
From  https://docs.python.org/2/library/threading.html : 
`class threading.Thread(group=None, target=None, name=None, args=(), kwargs={})`

This PR, also removes an unused import.
